### PR TITLE
fix: resolve AI serve swing glitch

### DIFF
--- a/docs/src/config/constants.js
+++ b/docs/src/config/constants.js
@@ -183,13 +183,12 @@ const GAME_CONFIG = {
         { name: "?", speed: 6, skillType: '?' }
     ],
 
-    // select AI's level after character for p2 was chosen.
     AI_LEVELS: {
         EASY: {
-            speedMult: 0.7,
-            reactionDelay: 13,
-            errorRange: 45,
-            prediction: 4
+            speedMult: 0.7,     // Directly proportional
+            reactionDelay: 13,  // Inversely proportional
+            errorRange: 45,     // Inversely proportional
+            prediction: 4       // Directly proportional
         },
         NORMAL: {
             speedMult: 0.8,
@@ -203,5 +202,21 @@ const GAME_CONFIG = {
             errorRange: 15,
             prediction: 10
         }
+    },
+
+    AI: {
+        FIDGET_SPEED: 0.015,        // Speed of lateral sway while receiving
+        HOME_X_DIVISOR: 4,          // Court ratio for receive home pos
+        FIDGET_RANGE_DIVISOR: 8,    // Court ratio for  lateral sway range
+        RECEIVE_X_THRESHOLD: 70,    
+        RECEIVE_Y_THRESHOLD: 100,
+        SERVE_DELAY_MIN: 90,
+        SERVE_DELAY_MAX: 160,
+        LERP_FACTOR_NORMAL: 0.2,
+        LERP_FACTOR_SERVE: 0.1,
+        SERVE_POS_PADDING: 10,
+        SERVE_DIST_THRESHOLD: 20,
+        SERVE_SWING_Z_MIN: 10,      // Min z height to swing during serve
+        SERVE_SWING_Z_MAX: 40       // Max z height to swing during serve
     }
 };

--- a/docs/src/entities/AI.js
+++ b/docs/src/entities/AI.js
@@ -2,34 +2,40 @@ class AI {
     constructor(playerInstance) {
         this.player = playerInstance;
         this.noiseOffset = random(1000);
-        this.fidgetSpeed = 0.015;
+        this.fidgetSpeed = GAME_CONFIG.AI.FIDGET_SPEED;
         this.serveDelayTimer = -1;
         this.serveTargetX = -1;
         this.targetX = width / 2;
-    
-        // default: Normal
+        this.serveSwung = false; 
+
         const defaultLevel = GAME_CONFIG.AI_LEVELS.NORMAL;
         this.difficulty     = 'NORMAL';
         this.speedMult      = defaultLevel.speedMult;
         this.reactionDelay  = defaultLevel.reactionDelay;
         this.errorRange     = defaultLevel.errorRange;
         this.prediction     = defaultLevel.prediction;
-    
+
         this._reactionCounter = 0;
     }
-    
+
+    resetServeState() {
+        this.serveDelayTimer = -1;
+        this.serveTargetX = -1;
+        this.serveSwung = false;
+    }
+
     update(ball) {
         this._reactionCounter++;
         if (this._reactionCounter >= this.reactionDelay) {
             this._reactionCounter = 0;
-    
+
             if (ball.isWaiting || ball.isTossing) {
                 if (scoreManager.currentServer === 'PLAYER') {
                     let isPlayerOnRight = player.x > layout.centerX;
                     let homeX = isPlayerOnRight ?
-                        layout.courtLeft + (layout.COURT_W / 4) :
-                        layout.courtRight - (layout.COURT_W / 4);
-                    let fidgetRange = layout.COURT_W / 8;
+                        layout.courtLeft + (layout.COURT_W / GAME_CONFIG.AI.HOME_X_DIVISOR) :
+                        layout.courtRight - (layout.COURT_W / GAME_CONFIG.AI.HOME_X_DIVISOR);
+                    let fidgetRange = layout.COURT_W / GAME_CONFIG.AI.FIDGET_RANGE_DIVISOR;
                     let noiseValue = (noise(this.noiseOffset) - 0.5) * fidgetRange;
                     this.noiseOffset += this.fidgetSpeed;
                     this.targetX = homeX + noiseValue;
@@ -43,26 +49,27 @@ class AI {
                 this.serveTargetX = -1;
             }
         }
-    
-        // moving and actions are executed per frame
+
         this.applySmoothMovement();
         this.handleActions(ball);
     }
-    
+
     applySmoothMovement() {
         let dx = this.targetX - this.player.x;
         if (Math.abs(dx) < 3) return;
-        let lerpFactor = (scoreManager.currentServer === 'PLAYER' && !ball.isWaiting) ? 0.2 : 0.1;
+        let lerpFactor = (scoreManager.currentServer === 'PLAYER' && !ball.isWaiting) 
+            ? GAME_CONFIG.AI.LERP_FACTOR_NORMAL 
+            : GAME_CONFIG.AI.LERP_FACTOR_SERVE;
         let moveStep = dx * lerpFactor;
-        // multiplying "speedMult" reflects the speed diff by difficulty
-        moveStep = constrain(moveStep, -this.player.speed * this.speedMult, this.player.speed * this.speedMult);
+        moveStep = constrain(moveStep, -this.player.speed * this.speedMult,
+            this.player.speed * this.speedMult);
         this.player.x += moveStep;
     }
 
     calculateServePosition() {
         if (this.serveTargetX !== -1) return this.serveTargetX;
         const { courtLeft, courtRight, centerX } = layout;
-        const padding = (this.player.w / 2) + 10; 
+        const padding = (this.player.w / 2) + GAME_CONFIG.AI.SERVE_POS_PADDING;
         if (scoreManager.currentSide === 'RIGHT') {
             this.serveTargetX = random(centerX + padding, courtRight - padding);
         } else {
@@ -75,25 +82,33 @@ class AI {
         if (!ball.isWaiting && !ball.isTossing && ball.vy < 0) {
             let xDiff = Math.abs(this.player.x - ball.x);
             let yDiff = Math.abs(this.player.y - ball.y);
-            if (xDiff < 70 && yDiff < 100) {
+            if (xDiff < GAME_CONFIG.AI.RECEIVE_X_THRESHOLD &&
+                 yDiff < GAME_CONFIG.AI.RECEIVE_Y_THRESHOLD) {
                 this.player.swing();
             }
         }
 
         if (scoreManager.currentServer === 'OPPONENT') {
             if (ball.isWaiting) {
+                this.serveSwung = false; 
                 if (this.serveDelayTimer === -1) {
-                    this.serveDelayTimer = int(random(90, 160));
+                    this.serveDelayTimer = int(random(
+                        GAME_CONFIG.AI.SERVE_DELAY_MIN,
+                        GAME_CONFIG.AI.SERVE_DELAY_MAX));
                 }
                 let distToTarget = Math.abs(this.player.x - this.serveTargetX);
-                if (distToTarget < 20 && this.serveDelayTimer > 0) {
+                if (distToTarget < GAME_CONFIG.AI.SERVE_DIST_THRESHOLD && this.serveDelayTimer > 0) {
                     this.serveDelayTimer--;
                 } else if (this.serveDelayTimer === 0) {
                     ball.toss();
                     this.serveDelayTimer = -1;
                 }
-            } else if (ball.isTossing && ball.z > 55) {
+            } else if (ball.isTossing && !this.serveSwung && 
+                        ball.vz < 0 &&
+                        ball.z > GAME_CONFIG.AI.SERVE_SWING_Z_MIN && 
+                        ball.z < GAME_CONFIG.AI.SERVE_SWING_Z_MAX) {
                 this.player.swing();
+                this.serveSwung = true;
             }
         }
     }


### PR DESCRIPTION
The bug where AI opponent was swinging multiple times during a single serve toss was fixed.

Changes:
- Glitch Fix: Implemented a state-check flag to ensure the AI only swings once per toss.
- Refactor: Moved hard-coded values from AI.js to Constants.js for better maintainability.

Could you please check if AI's serve is working correctly?
(I wanted AI opponent to swing and hit the ball at a random timing during a serve. But it didn't go well. I might attempt the implementation again later.)

Thank you!!
